### PR TITLE
feat: end-on-layer-deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ has elapsed after releasing the Tri-State or a ignored key.
   change to layer 2 **does** fire the interrupt behavior, because it is not
   included in `ignored-layers`.
 
+#### `end-on-layer-deactivation`
+
+- By default, layer deactivations never end the tri-state, only activations do
+  (see `ignored-layers`).
+- Layers listed here end the tri-state when they are deactivated. Useful when a
+  layer can drop with no key event left to interrupt, for example num-word
+  releasing on the tri-state's own keycode, which otherwise leaves the
+  tri-state held until `timeout-ms`.
+- Like `ignored-layers`, this is an array of layer indexes. The two lists are
+  independent of each other.
+
 ## References
 
 - Nick Conway's original behavior

--- a/behaviors/behavior_tri_state.c
+++ b/behaviors/behavior_tri_state.c
@@ -30,6 +30,7 @@ struct behavior_tri_state_config {
     uint32_t ignored_layers;
     int32_t timeout_ms;
     int tap_ms;
+    bool interrupt_on_layer_deactivation;
     uint8_t ignored_key_positions[];
 };
 
@@ -37,6 +38,7 @@ struct active_tri_state {
     bool is_active;
     bool is_pressed;
     bool first_press;
+    bool interrupt_deferred;
     uint32_t position;
 #if IS_ENABLED(CONFIG_ZMK_SPLIT)
     uint8_t source;
@@ -90,6 +92,7 @@ void behavior_tri_state_timer_handler(struct k_work *item) {
     }
     LOG_DBG("Tri-state deactivated due to timer");
     tri_state->is_active = false;
+    tri_state->interrupt_deferred = false;
     trigger_end_behavior(tri_state);
 }
 
@@ -120,6 +123,7 @@ static int new_tri_state(struct zmk_behavior_binding_event *event, const struct 
             ref_tri_state->is_pressed = false;
             ref_tri_state->first_press = true;
             ref_tri_state->timer_cancelled = false;
+            ref_tri_state->interrupt_deferred = false;
             *tri_state = ref_tri_state;
             return 0;
         }
@@ -177,7 +181,11 @@ static void release_tri_state(struct zmk_behavior_binding_event event,
     }
     tri_state->is_pressed = false;
     zmk_behavior_invoke_binding(continue_behavior, event, false);
-    reset_timer(k_uptime_get(), tri_state);
+    if (tri_state->interrupt_deferred) {
+        k_work_schedule(&tri_state->release_timer, K_NO_WAIT);
+    } else {
+        reset_timer(k_uptime_get(), tri_state);
+    }
 }
 
 static int on_tri_state_binding_released(struct zmk_behavior_binding *binding,
@@ -264,12 +272,24 @@ static int tri_state_layer_state_changed_listener(const zmk_event_t *eh) {
     if (ev == NULL) {
         return ZMK_EV_EVENT_BUBBLE;
     }
-    if (!ev->state) {
-        return ZMK_EV_EVENT_BUBBLE;
-    }
     for (int i = 0; i < ZMK_BHV_MAX_ACTIVE_TRI_STATES; i++) {
         struct active_tri_state *tri_state = &active_tri_states[i];
         if (!tri_state->is_active) {
+            continue;
+        }
+        if (!ev->state) {
+            // Deactivations can arrive mid-event (e.g. an auto-layer dropping on the
+            // tri-state's own keycode); end via the release timer so the queued end
+            // behavior runs with clean ordering instead of nesting into this event.
+            if (tri_state->config->interrupt_on_layer_deactivation &&
+                !is_layer_ignored(tri_state, ev->layer) && !tri_state->interrupt_deferred) {
+                LOG_DBG("Tri-State layer deactivated, deferring end at %d %d",
+                        tri_state->position, ev->layer);
+                tri_state->interrupt_deferred = true;
+                stop_timer(tri_state);
+                tri_state->timer_cancelled = false;
+                k_work_schedule(&tri_state->release_timer, K_NO_WAIT);
+            }
             continue;
         }
         if (!is_layer_ignored(tri_state, ev->layer)) {
@@ -309,6 +329,7 @@ static int tri_state_layer_state_changed_listener(const zmk_event_t *eh) {
         .ignored_layers = DT_INST_FOREACH_PROP_ELEM(n, ignored_layers, IF_BIT) 0,                  \
         .timeout_ms = DT_INST_PROP(n, timeout_ms),                                                 \
         .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
+        .interrupt_on_layer_deactivation = DT_INST_PROP(n, interrupt_on_layer_deactivation),       \
         .start_behavior = _TRANSFORM_ENTRY(0, n),                                                  \
         .continue_behavior = _TRANSFORM_ENTRY(1, n),                                               \
         .end_behavior = _TRANSFORM_ENTRY(2, n)};                                                   \

--- a/behaviors/behavior_tri_state.c
+++ b/behaviors/behavior_tri_state.c
@@ -28,9 +28,9 @@ struct behavior_tri_state_config {
     struct zmk_behavior_binding continue_behavior;
     struct zmk_behavior_binding end_behavior;
     uint32_t ignored_layers;
+    uint32_t end_on_layer_deactivation;
     int32_t timeout_ms;
     int tap_ms;
-    bool interrupt_on_layer_deactivation;
     uint8_t ignored_key_positions[];
 };
 
@@ -147,6 +147,13 @@ static bool is_layer_ignored(struct active_tri_state *tri_state, int32_t layer) 
     return false;
 }
 
+static bool is_layer_ending(struct active_tri_state *tri_state, int32_t layer) {
+    if ((BIT(layer) & tri_state->config->end_on_layer_deactivation) != 0U) {
+        return true;
+    }
+    return false;
+}
+
 static int on_tri_state_binding_pressed(struct zmk_behavior_binding *binding,
                                         struct zmk_behavior_binding_event event) {
     const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
@@ -182,7 +189,7 @@ static void release_tri_state(struct zmk_behavior_binding_event event,
     tri_state->is_pressed = false;
     zmk_behavior_invoke_binding(continue_behavior, event, false);
     if (tri_state->interrupt_deferred) {
-        k_work_schedule(&tri_state->release_timer, K_NO_WAIT);
+        k_work_reschedule(&tri_state->release_timer, K_NO_WAIT);
     } else {
         reset_timer(k_uptime_get(), tri_state);
     }
@@ -277,36 +284,37 @@ static int tri_state_layer_state_changed_listener(const zmk_event_t *eh) {
         if (!tri_state->is_active) {
             continue;
         }
+        bool interrupt = ev->state
+                             ? !is_layer_ignored(tri_state, ev->layer)  // activation: unless ignored
+                             : is_layer_ending(tri_state, ev->layer);   // deactivation: only if listed
+        if (!interrupt) {
+            continue;
+        }
         if (!ev->state) {
             // Deactivations can arrive mid-event (e.g. an auto-layer dropping on the
             // tri-state's own keycode); end via the release timer so the queued end
             // behavior runs with clean ordering instead of nesting into this event.
-            if (tri_state->config->interrupt_on_layer_deactivation &&
-                !is_layer_ignored(tri_state, ev->layer) && !tri_state->interrupt_deferred) {
+            if (!tri_state->interrupt_deferred) {
                 LOG_DBG("Tri-State layer deactivated, deferring end at %d %d",
                         tri_state->position, ev->layer);
                 tri_state->interrupt_deferred = true;
-                stop_timer(tri_state);
-                tri_state->timer_cancelled = false;
-                k_work_schedule(&tri_state->release_timer, K_NO_WAIT);
+                k_work_reschedule(&tri_state->release_timer, K_NO_WAIT);
             }
             continue;
         }
-        if (!is_layer_ignored(tri_state, ev->layer)) {
-            LOG_DBG("Tri-State layer changed, ending at %d %d", tri_state->position, ev->layer);
-            tri_state->is_active = false;
-            struct zmk_behavior_binding_event event = {.position = tri_state->position,
-                                                       .timestamp = k_uptime_get()};
-            if (tri_state->is_pressed) {
-                zmk_behavior_invoke_binding(
-                    (struct zmk_behavior_binding *)&tri_state->config->continue_behavior, event, false);
-            }
+        LOG_DBG("Tri-State layer changed, ending at %d %d", tri_state->position, ev->layer);
+        tri_state->is_active = false;
+        struct zmk_behavior_binding_event event = {.position = tri_state->position,
+                                                   .timestamp = k_uptime_get()};
+        if (tri_state->is_pressed) {
             zmk_behavior_invoke_binding(
-                (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, true);
-            zmk_behavior_invoke_binding(
-                (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, false);
-            return ZMK_EV_EVENT_BUBBLE;
+                (struct zmk_behavior_binding *)&tri_state->config->continue_behavior, event, false);
         }
+        zmk_behavior_invoke_binding(
+            (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, true);
+        zmk_behavior_invoke_binding(
+            (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, false);
+        return ZMK_EV_EVENT_BUBBLE;
     }
     return ZMK_EV_EVENT_BUBBLE;
 }
@@ -327,9 +335,10 @@ static int tri_state_layer_state_changed_listener(const zmk_event_t *eh) {
         .ignored_key_positions = DT_INST_PROP(n, ignored_key_positions),                           \
         .ignored_key_positions_len = DT_INST_PROP_LEN(n, ignored_key_positions),                   \
         .ignored_layers = DT_INST_FOREACH_PROP_ELEM(n, ignored_layers, IF_BIT) 0,                  \
+        .end_on_layer_deactivation =                                                               \
+            DT_INST_FOREACH_PROP_ELEM(n, end_on_layer_deactivation, IF_BIT) 0,                     \
         .timeout_ms = DT_INST_PROP(n, timeout_ms),                                                 \
         .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
-        .interrupt_on_layer_deactivation = DT_INST_PROP(n, interrupt_on_layer_deactivation),       \
         .start_behavior = _TRANSFORM_ENTRY(0, n),                                                  \
         .continue_behavior = _TRANSFORM_ENTRY(1, n),                                               \
         .end_behavior = _TRANSFORM_ENTRY(2, n)};                                                   \

--- a/behaviors/behavior_tri_state.c
+++ b/behaviors/behavior_tri_state.c
@@ -314,7 +314,8 @@ static int tri_state_layer_state_changed_listener(const zmk_event_t *eh) {
             (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, true);
         zmk_behavior_invoke_binding(
             (struct zmk_behavior_binding *)&tri_state->config->end_behavior, event, false);
-        return ZMK_EV_EVENT_BUBBLE;
+        // Keep scanning: several tri-states can be active at once.
+        continue;
     }
     return ZMK_EV_EVENT_BUBBLE;
 }

--- a/dts/bindings/behaviors/zmk,behavior-tri-state.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-tri-state.yaml
@@ -19,6 +19,15 @@ properties:
     type: array
     required: false
     default: []
+  interrupt-on-layer-deactivation:
+    type: boolean
+    description: |
+      Also interrupt the tri-state when a non-ignored layer is deactivated.
+      Off by default: a tri-state on a momentary layer whose trigger key is in
+      ignored-key-positions relies on surviving the layer release. Enable when
+      the layer may be deactivated without any accompanying key event (e.g. an
+      auto-layer/num-word or sticky layer dropping), which would otherwise
+      leave the tri-state held until timeout.
   timeout-ms:
     type: int
     default: -1

--- a/dts/bindings/behaviors/zmk,behavior-tri-state.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-tri-state.yaml
@@ -19,15 +19,17 @@ properties:
     type: array
     required: false
     default: []
-  interrupt-on-layer-deactivation:
-    type: boolean
+  end-on-layer-deactivation:
+    type: array
+    required: false
+    default: []
     description: |
-      Also interrupt the tri-state when a non-ignored layer is deactivated.
-      Off by default: a tri-state on a momentary layer whose trigger key is in
-      ignored-key-positions relies on surviving the layer release. Enable when
-      the layer may be deactivated without any accompanying key event (e.g. an
-      auto-layer/num-word or sticky layer dropping), which would otherwise
-      leave the tri-state held until timeout.
+      Layers whose deactivation ends the tri-state. Empty by default: a
+      tri-state on a momentary layer whose trigger key is in
+      ignored-key-positions relies on surviving the layer release. List a
+      layer here when it may be deactivated without any accompanying key
+      event (e.g. an auto-layer/num-word or sticky layer dropping), which
+      would otherwise leave the tri-state held until timeout.
   timeout-ms:
     type: int
     default: -1

--- a/tests/swapper-layer-deactivation-int/events.patterns
+++ b/tests/swapper-layer-deactivation-int/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode/kp/p
+s/.*on_tri_state_binding/tri_state_binding/p

--- a/tests/swapper-layer-deactivation-int/keycode_events.snapshot
+++ b/tests/swapper-layer-deactivation-int/keycode_events.snapshot
@@ -4,6 +4,8 @@ kp_pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
 kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 tri_state_binding_released: 0 tri_state keybind released
 kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
-kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
-kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+tri_state_binding_pressed: 0 tri_state pressed
+kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
+tri_state_binding_released: 0 tri_state keybind released
+kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 kp_released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00

--- a/tests/swapper-layer-deactivation-int/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation-int/native_posix_64.keymap
@@ -1,0 +1,30 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+/* Deferred end vs the continue behavior: the tri-state is pressed twice
+ * while layer 1 is up, then toggling layer 1 off (position 3 is ignored)
+ * deactivates it with no interrupting key event. With layer 1 listed in
+ * end-on-layer-deactivation the tri-state must end right there, not at
+ * timeout. */
+
+&swap {
+    end-on-layer-deactivation = <1>;
+};
+
+&kscan {
+    events = <
+    /* two full taps, LALT held across them */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* tog 1: ignored position, and layer 1 activation is in ignored-layers */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    /* trans on layer 1 falls through to tog 1: layer 1 deactivates */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
+    >;
+};

--- a/tests/swapper-layer-deactivation-int/native_sim.keymap
+++ b/tests/swapper-layer-deactivation-int/native_sim.keymap
@@ -1,0 +1,30 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+/* Deferred end vs the continue behavior: the tri-state is pressed twice
+ * while layer 1 is up, then toggling layer 1 off (position 3 is ignored)
+ * deactivates it with no interrupting key event. With layer 1 listed in
+ * end-on-layer-deactivation the tri-state must end right there, not at
+ * timeout. */
+
+&swap {
+    end-on-layer-deactivation = <1>;
+};
+
+&kscan {
+    events = <
+    /* two full taps, LALT held across them */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* tog 1: ignored position, and layer 1 activation is in ignored-layers */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    /* trans on layer 1 falls through to tog 1: layer 1 deactivates */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
+    >;
+};

--- a/tests/swapper-layer-deactivation-off/events.patterns
+++ b/tests/swapper-layer-deactivation-off/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode/kp/p
+s/.*on_tri_state_binding/tri_state_binding/p

--- a/tests/swapper-layer-deactivation-off/keycode_events.snapshot
+++ b/tests/swapper-layer-deactivation-off/keycode_events.snapshot
@@ -1,0 +1,8 @@
+tri_state_binding_pressed: 0 created new tri_state
+tri_state_binding_pressed: 0 tri_state pressed
+kp_pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
+tri_state_binding_released: 0 tri_state keybind released
+kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/tests/swapper-layer-deactivation-off/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation-off/native_posix_64.keymap
@@ -1,0 +1,53 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/* Same scenario as swapper-layer-deactivation but WITHOUT
+ * interrupt-on-layer-deactivation: the default behavior ignores layer
+ * deactivations, so the start behavior is held until timeout-ms. */
+
+/ {
+    behaviors {
+        swap: swap {
+            compatible = "zmk,behavior-tri-state";
+            #binding-cells = <0>;
+            bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
+            ignored-key-positions = <3>;
+            timeout-ms = <200>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        label = "Default keymap";
+
+        default_layer {
+            bindings = <
+                &sl 1    &kp A
+                &kp B    &kp C>;
+        };
+
+        extra_layer {
+            bindings = <
+                &swap    &trans
+                &trans   &trans>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    /* arm the sticky layer */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* same position now hits &swap on layer 1; the sticky layer quick-releases
+     * on this press, deactivating the layer with no key event */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,100)
+    /* the gap is shorter than timeout-ms and the trailing key is in
+     * ignored-key-positions: LALT is still held when it arrives (it comes
+     * out ALT-modified) and is only released by the timer */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    >;
+};

--- a/tests/swapper-layer-deactivation-off/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation-off/native_posix_64.keymap
@@ -44,10 +44,10 @@
      * on this press, deactivating the layer with no key event */
     ZMK_MOCK_PRESS(0,0,10)
     ZMK_MOCK_RELEASE(0,0,100)
-    /* the gap is shorter than timeout-ms and the trailing key is in
-     * ignored-key-positions: LALT is still held when it arrives (it comes
-     * out ALT-modified) and is only released by the timer */
+    /* the trailing key is in ignored-key-positions, so it does not
+     * interrupt; LALT is still held when it arrives and is only released
+     * by the timer, which the long tail of the last event lets fire */
     ZMK_MOCK_PRESS(1,1,10)
-    ZMK_MOCK_RELEASE(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
     >;
 };

--- a/tests/swapper-layer-deactivation-off/native_sim.keymap
+++ b/tests/swapper-layer-deactivation-off/native_sim.keymap
@@ -1,0 +1,53 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/* Same scenario as swapper-layer-deactivation but WITHOUT
+ * interrupt-on-layer-deactivation: the default behavior ignores layer
+ * deactivations, so the start behavior is held until timeout-ms. */
+
+/ {
+    behaviors {
+        swap: swap {
+            compatible = "zmk,behavior-tri-state";
+            #binding-cells = <0>;
+            bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
+            ignored-key-positions = <3>;
+            timeout-ms = <200>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        label = "Default keymap";
+
+        default_layer {
+            bindings = <
+                &sl 1    &kp A
+                &kp B    &kp C>;
+        };
+
+        extra_layer {
+            bindings = <
+                &swap    &trans
+                &trans   &trans>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    /* arm the sticky layer */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* same position now hits &swap on layer 1; the sticky layer quick-releases
+     * on this press, deactivating the layer with no key event */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,100)
+    /* the gap is shorter than timeout-ms and the trailing key is in
+     * ignored-key-positions: LALT is still held when it arrives (it comes
+     * out ALT-modified) and is only released by the timer */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    >;
+};

--- a/tests/swapper-layer-deactivation-off/native_sim.keymap
+++ b/tests/swapper-layer-deactivation-off/native_sim.keymap
@@ -44,10 +44,10 @@
      * on this press, deactivating the layer with no key event */
     ZMK_MOCK_PRESS(0,0,10)
     ZMK_MOCK_RELEASE(0,0,100)
-    /* the gap is shorter than timeout-ms and the trailing key is in
-     * ignored-key-positions: LALT is still held when it arrives (it comes
-     * out ALT-modified) and is only released by the timer */
+    /* the trailing key is in ignored-key-positions, so it does not
+     * interrupt; LALT is still held when it arrives and is only released
+     * by the timer, which the long tail of the last event lets fire */
     ZMK_MOCK_PRESS(1,1,10)
-    ZMK_MOCK_RELEASE(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
     >;
 };

--- a/tests/swapper-layer-deactivation/events.patterns
+++ b/tests/swapper-layer-deactivation/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode/kp/p
+s/.*on_tri_state_binding/tri_state_binding/p

--- a/tests/swapper-layer-deactivation/keycode_events.snapshot
+++ b/tests/swapper-layer-deactivation/keycode_events.snapshot
@@ -1,0 +1,9 @@
+tri_state_binding_pressed: 0 created new tri_state
+tri_state_binding_pressed: 0 tri_state pressed
+kp_pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
+tri_state_binding_released: 0 tri_state keybind released
+kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/tests/swapper-layer-deactivation/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation/native_posix_64.keymap
@@ -4,9 +4,9 @@
 
 /* A layer can be deactivated with no accompanying key event (a sticky layer
  * quick-releasing here; an auto-layer/num-word dropping on the tri-state's
- * own keycode in the wild). With interrupt-on-layer-deactivation set, the
- * tri-state ends as soon as the key is released instead of holding its start
- * behavior until timeout. */
+ * own keycode in the wild). With the layer listed in
+ * end-on-layer-deactivation, the tri-state ends as soon as the key is
+ * released instead of holding its start behavior until timeout. */
 
 / {
     behaviors {
@@ -16,7 +16,7 @@
             bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
             ignored-key-positions = <3>;
             timeout-ms = <200>;
-            interrupt-on-layer-deactivation;
+            end-on-layer-deactivation = <1>;
         };
     };
 

--- a/tests/swapper-layer-deactivation/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation/native_posix_64.keymap
@@ -47,10 +47,10 @@
      * on this press, deactivating the layer with no key event */
     ZMK_MOCK_PRESS(0,0,10)
     ZMK_MOCK_RELEASE(0,0,100)
-    /* the gap is shorter than timeout-ms and the trailing key is in
-     * ignored-key-positions: it comes out clean because LALT was already
-     * released at the swap key release */
+    /* the trailing key is in ignored-key-positions and comes out clean
+     * because LALT was already released at the swap key release; the long
+     * tail covers the timeout window to catch regressions */
     ZMK_MOCK_PRESS(1,1,10)
-    ZMK_MOCK_RELEASE(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
     >;
 };

--- a/tests/swapper-layer-deactivation/native_posix_64.keymap
+++ b/tests/swapper-layer-deactivation/native_posix_64.keymap
@@ -1,0 +1,56 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/* A layer can be deactivated with no accompanying key event (a sticky layer
+ * quick-releasing here; an auto-layer/num-word dropping on the tri-state's
+ * own keycode in the wild). With interrupt-on-layer-deactivation set, the
+ * tri-state ends as soon as the key is released instead of holding its start
+ * behavior until timeout. */
+
+/ {
+    behaviors {
+        swap: swap {
+            compatible = "zmk,behavior-tri-state";
+            #binding-cells = <0>;
+            bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
+            ignored-key-positions = <3>;
+            timeout-ms = <200>;
+            interrupt-on-layer-deactivation;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        label = "Default keymap";
+
+        default_layer {
+            bindings = <
+                &sl 1    &kp A
+                &kp B    &kp C>;
+        };
+
+        extra_layer {
+            bindings = <
+                &swap    &trans
+                &trans   &trans>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    /* arm the sticky layer */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* same position now hits &swap on layer 1; the sticky layer quick-releases
+     * on this press, deactivating the layer with no key event */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,100)
+    /* the gap is shorter than timeout-ms and the trailing key is in
+     * ignored-key-positions: it comes out clean because LALT was already
+     * released at the swap key release */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    >;
+};

--- a/tests/swapper-layer-deactivation/native_sim.keymap
+++ b/tests/swapper-layer-deactivation/native_sim.keymap
@@ -4,9 +4,9 @@
 
 /* A layer can be deactivated with no accompanying key event (a sticky layer
  * quick-releasing here; an auto-layer/num-word dropping on the tri-state's
- * own keycode in the wild). With interrupt-on-layer-deactivation set, the
- * tri-state ends as soon as the key is released instead of holding its start
- * behavior until timeout. */
+ * own keycode in the wild). With the layer listed in
+ * end-on-layer-deactivation, the tri-state ends as soon as the key is
+ * released instead of holding its start behavior until timeout. */
 
 / {
     behaviors {
@@ -16,7 +16,7 @@
             bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
             ignored-key-positions = <3>;
             timeout-ms = <200>;
-            interrupt-on-layer-deactivation;
+            end-on-layer-deactivation = <1>;
         };
     };
 

--- a/tests/swapper-layer-deactivation/native_sim.keymap
+++ b/tests/swapper-layer-deactivation/native_sim.keymap
@@ -47,10 +47,10 @@
      * on this press, deactivating the layer with no key event */
     ZMK_MOCK_PRESS(0,0,10)
     ZMK_MOCK_RELEASE(0,0,100)
-    /* the gap is shorter than timeout-ms and the trailing key is in
-     * ignored-key-positions: it comes out clean because LALT was already
-     * released at the swap key release */
+    /* the trailing key is in ignored-key-positions and comes out clean
+     * because LALT was already released at the swap key release; the long
+     * tail covers the timeout window to catch regressions */
     ZMK_MOCK_PRESS(1,1,10)
-    ZMK_MOCK_RELEASE(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,1000)
     >;
 };

--- a/tests/swapper-layer-deactivation/native_sim.keymap
+++ b/tests/swapper-layer-deactivation/native_sim.keymap
@@ -1,0 +1,56 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/* A layer can be deactivated with no accompanying key event (a sticky layer
+ * quick-releasing here; an auto-layer/num-word dropping on the tri-state's
+ * own keycode in the wild). With interrupt-on-layer-deactivation set, the
+ * tri-state ends as soon as the key is released instead of holding its start
+ * behavior until timeout. */
+
+/ {
+    behaviors {
+        swap: swap {
+            compatible = "zmk,behavior-tri-state";
+            #binding-cells = <0>;
+            bindings = <&kt LALT>, <&kp TAB>, <&kt LALT>;
+            ignored-key-positions = <3>;
+            timeout-ms = <200>;
+            interrupt-on-layer-deactivation;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        label = "Default keymap";
+
+        default_layer {
+            bindings = <
+                &sl 1    &kp A
+                &kp B    &kp C>;
+        };
+
+        extra_layer {
+            bindings = <
+                &swap    &trans
+                &trans   &trans>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    /* arm the sticky layer */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    /* same position now hits &swap on layer 1; the sticky layer quick-releases
+     * on this press, deactivating the layer with no key event */
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,100)
+    /* the gap is shorter than timeout-ms and the trailing key is in
+     * ignored-key-positions: it comes out clean because LALT was already
+     * released at the swap key release */
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    >;
+};


### PR DESCRIPTION
Adds an opt-in `end-on-layer-deactivation` property: layers listed there end the tri-state when they are deactivated.

A layer can be deactivated with no key event involved, e.g. num-word dropping on the tri-state's own keycode, or a sticky layer quick-releasing. Layer deactivations are otherwise ignored and there's no held key left to produce a position interrupt, so the tri-state keeps its start behavior held until `timeout-ms`.

Concrete case: a cmd-tab swapper on a smart-num layer. When the thumb resolves as tap, num-word holds the layer, the swapper's own Tab ends num-word, and cmd stays pressed until timeout, leaving the app switcher hanging open for 1.5s.

The end is deferred through the release timer instead of invoked inline: deactivations can arrive nested inside the tri-state's own keycode event, and ending there scrambles HID ordering (double start press, orphaned continue press).

The default (empty list) keeps current behavior, so setups that rely on surviving a layer release keep working. `swapper-layer-deactivation-off` pins that down.